### PR TITLE
saltカラムの再度追加、Userモデルのバリデーションの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
-  has_secure_password
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
-  validates :password, presence: true, if: -> { new_record? || changes[:crypted_password] }
+  validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :username, presence: true, length: { maximum: 255 }
   validates :email, presence: true, uniqueness: true
 

--- a/db/migrate/20240624011206_add_salt_to_users.rb
+++ b/db/migrate/20240624011206_add_salt_to_users.rb
@@ -1,0 +1,5 @@
+class AddSaltToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :salt, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_23_144225) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_24_011206) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,6 +43,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_23_144225) do
     t.string "avatar_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "salt"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION
saltカラムの再度追加、Userモデルのバリデーションの修正
---

- Userテーブルから削除したsaltカラムを再度追加
- validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }の追記
- Userモデルから「has_secure_password」の記載を削除