### PR TITLE
fix_Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,11 @@ COPY --from=build /rails /rails
 
 # Run and own only the runtime files as a non-root user for security
 RUN useradd rails --create-home --shell /bin/bash && \
-    chown -R rails:rails db log storage tmp
+    chown -R rails:rails db log storage tmp && \
+    mkdir -p /rails/public/uploads/tmp && \
+    chown -R rails:rails /rails/public/uploads && \
+    chmod -R 755 /rails/public/uploads && \
+    chmod -R 700 /rails/public/uploads/tmp
 USER rails:rails
 
 # Copy the entrypoint script and set permissions


### PR DESCRIPTION
本番環境の新規投稿機能で権限のエラーが発生したため、Dockerfileに下記内容を追記

RUN useradd rails --create-home --shell /bin/bash && \
    chown -R rails:rails db log storage tmp && \
    mkdir -p /rails/public/uploads/tmp && \
    chown -R rails:rails /rails/public/uploads && \
    chmod -R 755 /rails/public/uploads && \
    chmod -R 700 /rails/public/uploads/tmp
USER rails:rails