### PR TITLE
ランキング機能の実装、ジョブの設定

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y curl libvips postgresql-client imagemagick cron && \
     rm -rf /var/lib/apt/lists /var/cache/apt/archives
 
+# Ensure /var/run exists and has appropriate permissions
+RUN mkdir -p /var/run && chmod -R 777 /var/run
+
 # Copy built artifacts: gems, application
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /rails /rails


### PR DESCRIPTION
ランキング機能の実装、ジョブの設定

Dockerfileの修正
cron が /var/run/crond.pid ファイルを作成できるようにするために、ファイルシステムの権限を設定する記載の追加